### PR TITLE
Random drop

### DIFF
--- a/pyprob/nn/dataset.py
+++ b/pyprob/nn/dataset.py
@@ -361,7 +361,7 @@ class DistributedTraceBatchSampler(Sampler):
             num_batches = math.floor(len(bucket) / self._world_size)
             # Select a num_batches-sized subset of the current bucket for the current node
             # The part not selected by the current node will be selected by other nodes
-            batches = bucket[self._rank:len(bucket):self._world_size][:num_batches]
+            batches = bucket[(len(bucket)%(self._world_size)+self._rank):len(bucket):self._world_size][:num_batches]
             if self._shuffle_batches:
                 # Shuffle the list of minibatches (but not the order trace indices inside each minibatch) selected for the current node
                 np.random.shuffle(batches)

--- a/pyprob/nn/dataset.py
+++ b/pyprob/nn/dataset.py
@@ -10,7 +10,7 @@ import numpy as np
 import uuid
 from termcolor import colored
 from collections import Counter, OrderedDict
-
+import random
 from .. import util
 from ..util import TraceMode, PriorInflation
 from ..concurrency import ConcurrentShelf
@@ -325,7 +325,11 @@ class DistributedTraceBatchSampler(Sampler):
         self._world_size = dist.get_world_size()
         self._rank = dist.get_rank()
         # List of all minibatches in the whole dataset, where each minibatch is a list of trace indices
-        self._batches = list(util.chunks(offline_dataset._sorted_indices, batch_size))
+        #self._batches = list(util.chunks(offline_dataset._sorted_indices, batch_size))
+        batches_skip = (len(offline_dataset._sorted_indices)/batch_size)%self._world_size
+        chosen_size = len(offline_dataset._sorted_indices)-batches_skip * batch_size
+        chosen_indices = random.sample(list(offline_dataset._sorted_indices), chosen_size)
+        self._batches = list(util.chunks(chosen_indices, batch_size))
         # Discard last minibatch if it's smaller than batch_size
         if len(self._batches[-1]) < batch_size:
             del(self._batches[-1])
@@ -361,7 +365,7 @@ class DistributedTraceBatchSampler(Sampler):
             num_batches = math.floor(len(bucket) / self._world_size)
             # Select a num_batches-sized subset of the current bucket for the current node
             # The part not selected by the current node will be selected by other nodes
-            batches = bucket[(len(bucket)%(self._world_size)+self._rank):len(bucket):self._world_size][:num_batches]
+            batches = bucket[self._rank:len(bucket):self._world_size][:num_batches]
             if self._shuffle_batches:
                 # Shuffle the list of minibatches (but not the order trace indices inside each minibatch) selected for the current node
                 np.random.shuffle(batches)

--- a/pyprob/nn/dataset.py
+++ b/pyprob/nn/dataset.py
@@ -327,7 +327,8 @@ class DistributedTraceBatchSampler(Sampler):
         # List of all minibatches in the whole dataset, where each minibatch is a list of trace indices
         #self._batches = list(util.chunks(offline_dataset._sorted_indices, batch_size))
         batches_skip = (len(offline_dataset._sorted_indices)/batch_size)%self._world_size
-        chosen_size = len(offline_dataset._sorted_indices)-batches_skip * batch_size
+        #chosen_size = len(offline_dataset._sorted_indices)-batches_skip * batch_size
+        chosen_size = int(len(offline_dataset._sorted_indices)-batches_skip * batch_size)
         chosen_indices = random.sample(list(offline_dataset._sorted_indices), chosen_size)
         self._batches = list(util.chunks(chosen_indices, batch_size))
         # Discard last minibatch if it's smaller than batch_size


### PR DESCRIPTION
Randomly drop traces so load is divisible by ranks (without having to cut the tail)